### PR TITLE
updates nginx config to run workers as root to avoid changing permiss…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 MAINTAINER Kevin Krummenauer <kevin@whiledo.de>
-ADD resources/nginx-cert.conf /etc/nginx/conf.d/nginx-cert.conf
+COPY resources/nginx.conf /etc/nginx/nginx.conf
+COPY resources/nginx-cert.conf /etc/nginx/conf.d/nginx-cert.conf

--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -1,0 +1,33 @@
+
+user  root;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+


### PR DESCRIPTION
updates nginx config to run workers as root to avoid changing permissions on docker.sock. 
Since /var/run/docker.sock isn't permanent (daemon restart will undo the chmod). Chmoding it to 0666 also adds vulnerability to the host this seemed like a better/safer solution. 