### PR TITLE
Support cert password provided in a docker secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Docker Remote API with TLS client authentication via container
 
-This images makes you publish your Docker Remote API by a container.  
-A client must authenticate with a client-TLS certificate.  
-This is an alternative way, instead of [configuring TLS on Docker directly](https://gist.github.com/kekru/974e40bb1cd4b947a53cca5ba4b0bbe5).  
+This images makes you publish your Docker Remote API by a container.
+A client must authenticate with a client-TLS certificate.
+This is an alternative way, instead of [configuring TLS on Docker directly](https://gist.github.com/kekru/974e40bb1cd4b947a53cca5ba4b0bbe5).
 
 ## Remote Api with external CA, certificates and key
 
-First you need a CA and certs and keys for your Docker server and the client.  
+First you need a CA and certs and keys for your Docker server and the client.
 
-Create them as shown here [Protect the Docker daemon socket](https://docs.docker.com/engine/security/https/).  
+Create them as shown here [Protect the Docker daemon socket](https://docs.docker.com/engine/security/https/).
 Or create the files with this script [create-certs.sh](https://github.com/kekru/linux-utils/blob/master/cert-generate/create-certs.sh). Read [Create certificate files](https://gist.github.com/kekru/974e40bb1cd4b947a53cca5ba4b0bbe5#create-certificate-files) for information on how to use the script.
 
-Copy the following files in a directory. The directory will me mounted in the container.  
+Copy the following files in a directory. The directory will me mounted in the container.
 
 ```bash
 ca-cert.pem
@@ -19,7 +19,7 @@ server-cert.pem
 server-key.pem
 ```
 
-The files `cert.pem` and `key.pem` are certificate and key for the client. The client will also need the `ca-cert.pem`.  
+The files `cert.pem` and `key.pem` are certificate and key for the client. The client will also need the `ca-cert.pem`.
 
 Create a docker-compose.yml file:
 
@@ -35,13 +35,15 @@ services:
      - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
-Now run the container with `docker-compose up -d` or `docker stack deploy --compose-file=docker-compose.yml remoteapi`.  
+Now run the container with `docker-compose up -d` or `docker stack deploy --compose-file=docker-compose.yml remoteapi`.
 Your Docker Remote API is available on port 2376 via https. The client needs to authenticate via `cert.pem` and `key.pem`.
 
 ## Remote Api with auto generating CA, certificates and keys
 
-The docker-remote-api image can generate CA, certificates and keys for you automatically.  
+The docker-remote-api image can generate CA, certificates and keys for you automatically.
 Create a docker-compose.yml file, specifying a password and the hostname, on which the remote api will be accessible later on. The hostname will be written to the server's certificate.
+
+Optionally, the cert password can be provided as a docker secret. In this case use the `CERTS_PASSWORD_FILE` variable with the absolute path of secret file: `CERTS_PASSWORD_FILE=/run/secrets/<secret_name>`. If both `CREATE_CERTS_WITH_PW` and `CERTS_PASSWORD_FILE` are provided, `CERTS_PASSWORD_FILE` takes precedence.
 
 ```yml
 version: "3.4"
@@ -58,9 +60,9 @@ services:
      - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
-Now run the container with `docker-compose up -d` or `docker stack deploy --compose-file=docker-compose.yml remoteapi`.  
-Certificates will be creates in `<local cert dir>`.  
-You will find the client-certs in `<local cert dir>/client/`. The files are `ca.pem`, `cert.pem` and `key.pem`.  
+Now run the container with `docker-compose up -d` or `docker stack deploy --compose-file=docker-compose.yml remoteapi`.
+Certificates will be created in `<local cert dir>`.
+You will find the client-certs in `<local cert dir>/client/`. The files are `ca.pem`, `cert.pem` and `key.pem`.
 
 ## Setup client
 

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+[ -n $CERTS_PASSWORD_FILE ] \
+  && CREATE_CERTS_WITH_PW="$(cat $CERTS_PASSWORD_FILE)"
+
 if [ -n $CREATE_CERTS_WITH_PW ]; then
   if [ -z "$(ls -A $CERTS_DIR)" ]; then
 
@@ -18,7 +21,7 @@ if [ -n $CREATE_CERTS_WITH_PW ]; then
     chmod 444 $CERTS_DIR/client/key.pem
 
   else
-  
+
     echo "$CERTS_DIR is not empty. Not creating certs."
   fi
 fi

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-[ -n $CERTS_PASSWORD_FILE ] \
-  && CREATE_CERTS_WITH_PW="$(cat $CERTS_PASSWORD_FILE)"
+if [ -n "$CERTS_PASSWORD_FILE" ]; then
+  echo "Using cert password from $CERTS_PASSWORD_FILE"
+  CREATE_CERTS_WITH_PW="$(cat $CERTS_PASSWORD_FILE)"
+fi
 
 if [ -n $CREATE_CERTS_WITH_PW ]; then
   if [ -z "$(ls -A $CERTS_DIR)" ]; then


### PR DESCRIPTION
To avoid having the cert password in plain text, use docker secrets instead when running in swarm mode.

Example compose file could be:

```yaml
version: '3.7'

services:
  api:
    image: kekru/docker-remote-api-tls:<version>
    ports:
     - 2376:443
    deploy:
      restart_policy:
        condition: on-failure
        max_attempts: 3
      mode: global
      placement:
        constraints:
          - node.role == manager
      update_config:
        parallelism: 1
        delay: 3s
    environment:
      CERTS_PASSWORD_FILE: /run/secrets/remote-api-cert-pw
      CERT_HOSTNAME: remote-api.example.com
    volumes:
     - <local cert dir>:/data/certs
     - /var/run/docker.sock:/var/run/docker.sock:ro
    secrets:
        - remote-api-cert-pw

secrets:
  remote-api-cert-pw:
    external: true
```